### PR TITLE
outputPath in apostrophes; fixes pathing issues

### DIFF
--- a/python/cut_padding/model.py
+++ b/python/cut_padding/model.py
@@ -18,7 +18,7 @@ def splitTask (data):
     try:
         outputPath = f'{outputDirectory}/{".".join(inPath.split("/")[-1].split(".")[:-1])}.wav'
 
-        command = f'{ffmpeg_path} -i "{inPath}" -af "silenceremove=start_periods=1:start_duration=1:start_threshold={min_dB}dB:detection=peak,aformat=dblp,areverse,silenceremove=start_periods=1:start_duration=1:start_threshold={min_dB}dB:detection=peak,aformat=dblp,areverse" {outputPath}'
+        command = f'{ffmpeg_path} -i "{inPath}" -af "silenceremove=start_periods=1:start_duration=1:start_threshold={min_dB}dB:detection=peak,aformat=dblp,areverse,silenceremove=start_periods=1:start_duration=1:start_threshold={min_dB}dB:detection=peak,aformat=dblp,areverse" "{outputPath}"'
         command_process = subprocess.Popen(command, startupinfo=startupinfo, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = command_process.communicate()
         stderr = stderr.decode("utf-8")


### PR DESCRIPTION
Steam is usually is located in "Program Files (x86)", so I couldn't get it to work due to spaces within outputPath.